### PR TITLE
Port for 1.19.2

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -101,11 +101,11 @@ dependencies {
     minecraft("net.minecraftforge:forge:${mcVersion}-${property("forgeVersion")}")
 
     // Compile PHC and DT, of course.
-    implementation(fg.deobf("curse.maven:pams-harvestcraft-2-trees-365460:4360314"))
+    implementation(fg.deobf("curse.maven:pams-harvestcraft-2-trees-365460:4480280"))
     implementation(fg.deobf("com.ferreusveritas.dynamictrees:DynamicTrees-$mcVersion:${property("dynamicTreesVersion")}"))
 
     // Compile Jade, but don't include in runtime.
-    compileOnly(fg.deobf("curse.maven:Jade-324717:4082408"))
+    compileOnly(fg.deobf("curse.maven:Jade-324717:4433884"))
 
     // DT+ is optional, but it's implemented as there is access to its classes and needs to be compiled.
     implementation(fg.deobf("com.ferreusveritas.dynamictreesplus:DynamicTreesPlus-$mcVersion:${property("dynamicTreesPlusVersion")}"))
@@ -115,27 +115,27 @@ dependencies {
     /////////////////////////////////////////
 
     // At runtime, use the full Jade mod.
-    runtimeOnly(fg.deobf("curse.maven:Jade-324717:4082408"))
+    runtimeOnly(fg.deobf("curse.maven:Jade-324717:4433884"))
 
     // At runtime, use the full JEI mod.
     // TEMP FIX: TEHNUT MAVEN IS DOWN
-    runtimeOnly(fg.deobf("curse.maven:jei-238222:4434393"))
+    runtimeOnly(fg.deobf("curse.maven:jei-238222:4615177"))
     //runtimeOnly(fg.deobf("mezz.jei:jei-$mcVersion:${property("jeiVersion")}"))
 
     // At runtime, use CC for creating growth chambers.
     runtimeOnly(fg.deobf("org.squiddev:cc-tweaked-$mcVersion:${property("ccVersion")}"))
 
     // At runtime, get rid of experimental settings warning screen.
-    runtimeOnly(fg.deobf("curse.maven:ShutUpExperimentalSettings-407174:3544525"))
+    runtimeOnly(fg.deobf("curse.maven:ShutUpExperimentalSettings-407174:3759881"))
 
     // At runtime use serene seasons to test seasonal mechanics
-    runtimeOnly(fg.deobf("curse.maven:SereneSeasons-291874:3693807"))
+    runtimeOnly(fg.deobf("curse.maven:SereneSeasons-291874:4037228"))
 
     // At runtime, use suggestion provider fix mod.
-    runtimeOnly(fg.deobf("com.harleyoconnor.suggestionproviderfix:SuggestionProviderFix-1.18.1:${property("suggestionProviderFixVersion")}"))
+    runtimeOnly(fg.deobf("com.harleyoconnor.suggestionproviderfix:SuggestionProviderFix-1.19:${property("suggestionProviderFixVersion")}"))
 
     // If needed, include Cyanide mod to get more info about datapack errors
-    runtimeOnly(fg.deobf("curse.maven:Cyanide-541676:3811793"))
+    runtimeOnly(fg.deobf("curse.maven:Cyanide-541676:4126944"))
 
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,20 +1,17 @@
 modName=DynamicTreesPHC2
 modId=dtphc2
-modVersion=1.1.0
+modVersion=1.2.0
 group=maxhyper.dtphc2
 
-mcVersion=1.18.2
-forgeVersion=40.2.0
-mappingsVersion=2022.11.06
+mcVersion=1.19.2
+forgeVersion=43.2.14
+mappingsVersion=2022.11.27
 
-dynamicTreesVersion=1.0.3
-dynamicTreesPlusVersion=1.0.4
+dynamicTreesVersion=1.1.0-BETA5
+dynamicTreesPlusVersion=1.1.1
 #jeiVersion=forge-10.2.1.1004
 ccVersion=1.101.2
 suggestionProviderFixVersion=1.0.0
-
-curseProjectId=839090
-curseFileType=release
 
 org.gradle.jvmargs=-Xmx3G
 org.gradle.daemon=false

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/maxhyper/dtphc2/DynamicTreesPHC2.java
+++ b/src/main/java/maxhyper/dtphc2/DynamicTreesPHC2.java
@@ -9,8 +9,7 @@ import com.ferreusveritas.dynamictrees.systems.fruit.Fruit;
 import com.ferreusveritas.dynamictrees.systems.pod.Pod;
 import com.ferreusveritas.dynamictrees.tree.family.Family;
 import com.ferreusveritas.dynamictrees.tree.species.Species;
-import com.pam.pamhc2trees.init.WorldGenRegistry;
-import com.pam.pamhc2trees.init.ItemRegistry;
+import com.pam.pamhc2trees.init.ItemRegistration;
 import maxhyper.dtphc2.init.DTPHC2Blocks;
 import maxhyper.dtphc2.compat.DTPConfig;
 import maxhyper.dtphc2.compat.DTPConfigProxy;
@@ -30,7 +29,7 @@ import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent;
 import net.minecraftforge.fml.event.lifecycle.FMLConstructModEvent;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
-import net.minecraftforge.forge.event.lifecycle.GatherDataEvent;
+import net.minecraftforge.data.event.GatherDataEvent;
 
 @Mod(DynamicTreesPHC2.MOD_ID)
 @Mod.EventBusSubscriber(modid = DynamicTreesPHC2.MOD_ID, bus = Mod.EventBusSubscriber.Bus.MOD)
@@ -117,9 +116,9 @@ public class DynamicTreesPHC2 {
 
     private void clientSetup(final FMLClientSetupEvent event) {
         DTPHC2Client.setup();
-        DTPHC2Blocks.PASSION_FRUIT_VINE.get().setFruitStack(new ItemStack(ItemRegistry.passionfruititem.get()));
-        DTPHC2Blocks.VANILLA_VINE.get().setFruitStack(new ItemStack(ItemRegistry.vanillabeanitem.get()));
-        DTPHC2Blocks.PEPPERCORN_VINE.get().setFruitStack(new ItemStack(ItemRegistry.peppercornitem.get())).setOverripeFruitStack(new ItemStack(DTPHC2Items.RIPE_PEPPERCORN_ITEM.get()));
+        DTPHC2Blocks.PASSION_FRUIT_VINE.get().setFruitStack(new ItemStack(ItemRegistration.passionfruititem.get()));
+        DTPHC2Blocks.VANILLA_VINE.get().setFruitStack(new ItemStack(ItemRegistration.vanillabeanitem.get()));
+        DTPHC2Blocks.PEPPERCORN_VINE.get().setFruitStack(new ItemStack(ItemRegistration.peppercornitem.get())).setOverripeFruitStack(new ItemStack(DTPHC2Items.RIPE_PEPPERCORN_ITEM.get()));
     }
 
     private void gatherData(final GatherDataEvent event) {

--- a/src/main/java/maxhyper/dtphc2/blocks/FallingFruitBlock.java
+++ b/src/main/java/maxhyper/dtphc2/blocks/FallingFruitBlock.java
@@ -7,6 +7,7 @@ import maxhyper.dtphc2.DynamicTreesPHC2;
 import net.minecraft.core.BlockPos;
 import net.minecraft.network.protocol.game.DebugPackets;
 import net.minecraft.server.level.ServerLevel;
+import net.minecraft.util.RandomSource;
 import net.minecraft.world.damagesource.DamageSource;
 import net.minecraft.world.entity.item.FallingBlockEntity;
 import net.minecraft.world.item.ItemStack;
@@ -17,7 +18,6 @@ import net.minecraft.world.level.block.state.BlockState;
 
 import javax.annotation.Nonnull;
 import java.util.List;
-import java.util.Random;
 
 public class FallingFruitBlock extends FruitBlock implements IFallingFruit {
 
@@ -32,7 +32,7 @@ public class FallingFruitBlock extends FruitBlock implements IFallingFruit {
     }
 
     @Override
-    public void doTick(BlockState state, Level world, BlockPos pos, Random random) {
+    public void doTick(BlockState state, Level world, BlockPos pos, RandomSource random) {
         if (checkToFall(state, world, pos, random)){
             doFall(state, world, pos);
         } else

--- a/src/main/java/maxhyper/dtphc2/blocks/FallingPodBlock.java
+++ b/src/main/java/maxhyper/dtphc2/blocks/FallingPodBlock.java
@@ -10,6 +10,7 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.network.protocol.game.DebugPackets;
 import net.minecraft.server.level.ServerLevel;
+import net.minecraft.util.RandomSource;
 import net.minecraft.world.damagesource.DamageSource;
 import net.minecraft.world.entity.item.FallingBlockEntity;
 import net.minecraft.world.item.ItemStack;
@@ -22,7 +23,6 @@ import net.minecraft.world.level.block.state.BlockState;
 
 import javax.annotation.Nonnull;
 import java.util.List;
-import java.util.Random;
 
 public class FallingPodBlock extends PodBlock implements IFallingFruit {
 
@@ -44,7 +44,7 @@ public class FallingPodBlock extends PodBlock implements IFallingFruit {
     }
 
     @Override
-    public void doTick(BlockState state, Level world, BlockPos pos, Random random) {
+    public void doTick(BlockState state, Level world, BlockPos pos, RandomSource random) {
         if (checkToFall(state, world, pos, random)){
             //System.out.println(this.asItem());
             doFall(state, world, pos);

--- a/src/main/java/maxhyper/dtphc2/blocks/FruitVineBlock.java
+++ b/src/main/java/maxhyper/dtphc2/blocks/FruitVineBlock.java
@@ -7,12 +7,12 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.tags.BlockTags;
+import net.minecraft.util.RandomSource;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.item.context.BlockPlaceContext;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
@@ -29,7 +29,6 @@ import net.minecraftforge.common.ForgeHooks;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import java.util.Random;
 
 import static com.ferreusveritas.dynamictrees.compat.season.SeasonHelper.isSeasonBetween;
 
@@ -120,7 +119,7 @@ public class FruitVineBlock extends VineBlock {
         builder.add(ageProperty);
     }
 
-    public void doTick(BlockState state, Level world, BlockPos pos, Random random) {
+    public void doTick(BlockState state, Level world, BlockPos pos, RandomSource random) {
         final Integer age = getAge(state);
         if (age == null) return;
         final Float season = SeasonHelper.getSeasonValue(LevelContext.create(world), pos);
@@ -139,7 +138,7 @@ public class FruitVineBlock extends VineBlock {
         }
     }
 
-    private void tryGrow(BlockState state, Level world, BlockPos pos, Random random, int age,
+    private void tryGrow(BlockState state, Level world, BlockPos pos, RandomSource random, int age,
                          @Nullable Float season) {
         float chance = age == 0 ? getFruitingChance(world, pos)
                 : ((matureAge != maxAge && age >= matureAge) ? fruitOverripenChance : fruitGrowChance);
@@ -281,7 +280,7 @@ public class FruitVineBlock extends VineBlock {
     }
 
     @Override
-    public void randomTick(BlockState state, ServerLevel world, BlockPos pos, Random random) {
+    public void randomTick(BlockState state, ServerLevel world, BlockPos pos, RandomSource random) {
         doTick(state, world, pos, random);
 
         if (world.random.nextFloat() < attemptSpread && world.isAreaLoaded(pos, 4)) { // Forge: check area to prevent loading unloaded chunks
@@ -361,6 +360,19 @@ public class FruitVineBlock extends VineBlock {
 
             }
         }
+    }
+
+    private BlockState copyRandomFaces(BlockState from, BlockState to, RandomSource random) {
+        for(Direction direction : Direction.Plane.HORIZONTAL) {
+            if (random.nextBoolean()) {
+                BooleanProperty booleanproperty = getPropertyForFace(direction);
+                if (from.getValue(booleanproperty)) {
+                    to = to.setValue(booleanproperty, Boolean.TRUE);
+                }
+            }
+        }
+
+        return to;
     }
 
 }

--- a/src/main/java/maxhyper/dtphc2/blocks/IFallingFruit.java
+++ b/src/main/java/maxhyper/dtphc2/blocks/IFallingFruit.java
@@ -1,14 +1,12 @@
 package maxhyper.dtphc2.blocks;
 
-import com.ferreusveritas.dynamictrees.util.MathHelper;
 import com.google.common.collect.Lists;
 import maxhyper.dtphc2.init.DTPHC2Registries;
 import net.minecraft.core.BlockPos;
 import net.minecraft.sounds.SoundSource;
-import net.minecraft.util.Mth;
+import net.minecraft.util.RandomSource;
 import net.minecraft.world.damagesource.DamageSource;
 import net.minecraft.world.entity.Entity;
-import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.item.FallingBlockEntity;
 import net.minecraft.world.entity.item.ItemEntity;
@@ -22,7 +20,6 @@ import net.minecraft.world.level.block.state.BlockState;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.List;
-import java.util.Random;
 
 public interface IFallingFruit {
 
@@ -31,7 +28,7 @@ public interface IFallingFruit {
 
     DamageSource getDamageSource();
 
-    default boolean checkToFall(BlockState state, Level world, BlockPos pos, Random random){
+    default boolean checkToFall(BlockState state, Level world, BlockPos pos, RandomSource random){
         if (getAge(state) < getMaxAge()) return false;
         return random.nextFloat() <= getRandomFruitFallChance();
     }

--- a/src/main/java/maxhyper/dtphc2/canceller/DTPHC2TreeFeatureCanceller.java
+++ b/src/main/java/maxhyper/dtphc2/canceller/DTPHC2TreeFeatureCanceller.java
@@ -1,33 +1,32 @@
 package maxhyper.dtphc2.canceller;
 
+import com.ferreusveritas.dynamictrees.api.worldgen.BiomePropertySelectors;
 import com.ferreusveritas.dynamictrees.api.worldgen.FeatureCanceller;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.level.levelgen.feature.ConfiguredFeature;
 import net.minecraft.world.level.levelgen.feature.Feature;
-import net.minecraft.world.level.levelgen.feature.WeightedPlacedFeature;
-import net.minecraft.world.level.levelgen.feature.configurations.FeatureConfiguration;
-import net.minecraft.world.level.levelgen.feature.configurations.NoneFeatureConfiguration;
-import net.minecraft.world.level.levelgen.feature.configurations.RandomFeatureConfiguration;
-import net.minecraft.world.level.levelgen.placement.PlacedFeature;
-
-import java.util.Objects;
-import java.util.Set;
+import net.minecraftforge.registries.ForgeRegistries;
 
 public class DTPHC2TreeFeatureCanceller extends FeatureCanceller {
 
-    private final Class<?>[] treeFeatureClasses;
+    private final ResourceLocation[] treeFeatureClasses;
 
-    public DTPHC2TreeFeatureCanceller(final ResourceLocation registryName, Class<?>... treeFeatureClass) {
+    public DTPHC2TreeFeatureCanceller(final ResourceLocation registryName, ResourceLocation[] treeFeatureClass) {
         super(registryName);
         this.treeFeatureClasses = treeFeatureClass;
     }
 
     @Override
-    public boolean shouldCancel(ConfiguredFeature<?, ?> configuredFeature, Set<String> namespaces) {
+    public boolean shouldCancel(ConfiguredFeature<?, ?> configuredFeature, BiomePropertySelectors.NormalFeatureCancellation featureCancellations) {
         Feature<?> feature = configuredFeature.feature();
-        if (namespaces.contains(Objects.requireNonNull(feature.getRegistryName()).getNamespace())) {
-            for (Class<?> treeFeatureClass : treeFeatureClasses){
-                if (treeFeatureClass.isInstance(feature))
+        ResourceLocation resource = ForgeRegistries.FEATURES.getKey(feature);
+        if (resource == null)
+            return false;
+        String namespace = resource.getNamespace();
+        var namespaces = featureCancellations.getNamespaces();
+        if (namespaces.contains(namespace)) {
+            for (var treeFeatureClass : treeFeatureClasses){
+                if (treeFeatureClass.compareTo(resource) == 0)
                     return true;
             }
         }

--- a/src/main/java/maxhyper/dtphc2/compat/waila/WailaCompat.java
+++ b/src/main/java/maxhyper/dtphc2/compat/waila/WailaCompat.java
@@ -2,7 +2,7 @@ package maxhyper.dtphc2.compat.waila;
 
 import maxhyper.dtphc2.blocks.FruitVineBlock;
 import maxhyper.dtphc2.blocks.MapleSpileCommon;
-import mcp.mobius.waila.api.*;
+import snownee.jade.api.*;
 
 @WailaPlugin
 public class WailaCompat implements IWailaPlugin {
@@ -10,14 +10,14 @@ public class WailaCompat implements IWailaPlugin {
     @SuppressWarnings("UnstableApiUsage")
     @Override
     public void registerClient(IWailaClientRegistration registration) {
-        registration.registerComponentProvider(WailaVineHandler.INSTANCE, TooltipPosition.BODY, FruitVineBlock.class);
-        registration.registerComponentProvider(WailaSpileHandler.INSTANCE, TooltipPosition.BODY, MapleSpileCommon.class);
-        registration.registerIconProvider(WailaSpileHandler.INSTANCE, MapleSpileCommon.class);
+        registration.registerBlockComponent(WailaVineHandler.INSTANCE, FruitVineBlock.class);
+        registration.registerBlockComponent(WailaSpileHandler.INSTANCE, MapleSpileCommon.class);
+        registration.registerBlockIcon(WailaSpileHandler.INSTANCE, MapleSpileCommon.class);
     }
 
     @SuppressWarnings("removal")
     @Override
-    public void register(IRegistrar registrar) {
+    public void register(IWailaCommonRegistration registrar) {
         //registrar.registerStackProvider(new WailaSpileHandler(), MapleSpileCommon.class);
     }
 

--- a/src/main/java/maxhyper/dtphc2/compat/waila/WailaSpileHandler.java
+++ b/src/main/java/maxhyper/dtphc2/compat/waila/WailaSpileHandler.java
@@ -6,20 +6,21 @@ import com.ferreusveritas.dynamictrees.tree.species.Species;
 import maxhyper.dtphc2.blocks.MapleSpileBlock;
 import maxhyper.dtphc2.blocks.MapleSpileBucketBlock;
 import maxhyper.dtphc2.blocks.MapleSpileCommon;
-import mcp.mobius.waila.api.BlockAccessor;
-import mcp.mobius.waila.api.IComponentProvider;
-import mcp.mobius.waila.api.ITooltip;
-import mcp.mobius.waila.api.config.IPluginConfig;
-import mcp.mobius.waila.api.ui.IElementHelper;
+import maxhyper.dtphc2.init.DTPHC2Blocks;
+import net.minecraft.resources.ResourceLocation;
+import snownee.jade.api.BlockAccessor;
+import snownee.jade.api.IBlockComponentProvider;
+import snownee.jade.api.ITooltip;
+import snownee.jade.api.config.IPluginConfig;
+import snownee.jade.api.ui.IElementHelper;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.network.chat.Component;
-import net.minecraft.network.chat.TranslatableComponent;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
 import net.minecraft.world.level.block.state.BlockState;
 
-public class WailaSpileHandler implements IComponentProvider {
+public class WailaSpileHandler implements IBlockComponentProvider {
 
     public static WailaSpileHandler INSTANCE = new WailaSpileHandler();
 
@@ -31,14 +32,14 @@ public class WailaSpileHandler implements IComponentProvider {
         if (accessor.getBlockState().hasProperty(MapleSpileBlock.FILLED)) {
             boolean filled = accessor.getBlockState().getValue(MapleSpileBlock.FILLED);
             Component filledText = filled
-                    ? new TranslatableComponent("tooltip.dtphc2.maple_spile_filled")
-                    : new TranslatableComponent("tooltip.dtphc2.maple_spile_not_filled");
+                    ? Component.translatable("tooltip.dtphc2.maple_spile_filled")
+                    : Component.translatable("tooltip.dtphc2.maple_spile_not_filled");
             tooltip.add(filledText);
         }
         if (accessor.getBlockState().hasProperty(MapleSpileBucketBlock.FILLING)) {
             int filling = accessor.getBlockState().getValue(MapleSpileBucketBlock.FILLING);
             float percent = filling / 3.0F * 100;
-            tooltip.add(new TranslatableComponent("tooltip.dtphc2.maple_spile_bucket_filling", String.format("%.0f%%", percent)));
+            tooltip.add(Component.translatable("tooltip.dtphc2.maple_spile_bucket_filling", String.format("%.0f%%", percent)));
         }
 
         // ADD ICON
@@ -87,4 +88,8 @@ public class WailaSpileHandler implements IComponentProvider {
     }
 
 
+    @Override
+    public ResourceLocation getUid() {
+        return DTPHC2Blocks.MAPLE_SPILE_BLOCK.getId();
+    }
 }

--- a/src/main/java/maxhyper/dtphc2/compat/waila/WailaVineHandler.java
+++ b/src/main/java/maxhyper/dtphc2/compat/waila/WailaVineHandler.java
@@ -1,29 +1,32 @@
 package maxhyper.dtphc2.compat.waila;
 
 import maxhyper.dtphc2.blocks.FruitVineBlock;
-import mcp.mobius.waila.api.BlockAccessor;
-import mcp.mobius.waila.api.IComponentProvider;
-import mcp.mobius.waila.api.ITooltip;
-import mcp.mobius.waila.api.TooltipPosition;
-import mcp.mobius.waila.api.config.IPluginConfig;
+import maxhyper.dtphc2.init.DTPHC2Blocks;
+import net.minecraft.network.chat.Component;
+import net.minecraft.resources.ResourceLocation;
+import snownee.jade.api.BlockAccessor;
+import snownee.jade.api.IBlockComponentProvider;
+import snownee.jade.api.ITooltip;
+import snownee.jade.api.config.IPluginConfig;
 import net.minecraft.ChatFormatting;
-import net.minecraft.network.chat.TranslatableComponent;
 
-import java.util.List;
-
-public class WailaVineHandler implements IComponentProvider {
+public class WailaVineHandler implements IBlockComponentProvider {
 
     public static WailaVineHandler INSTANCE = new WailaVineHandler();
     @Override
     public void appendTooltip(ITooltip tooltip, BlockAccessor accessor, IPluginConfig iPluginConfig) {
-        if (accessor.getTooltipPosition() != TooltipPosition.BODY) return;
         if (accessor.getBlock() instanceof FruitVineBlock fruitBlock) {
             float ageAsPercentage = fruitBlock.getAge(accessor.getBlockState()) * 100F / fruitBlock.getMatureAge();
-            tooltip.add(new TranslatableComponent(
+            tooltip.add(Component.translatable(
                     "tooltip.waila.crop_growth",
                     ageAsPercentage < 100F ? String.format("%.0f%%", ageAsPercentage) :
-                            new TranslatableComponent("tooltip.waila.crop_mature").withStyle(ChatFormatting.GREEN)
+                            Component.translatable("tooltip.waila.crop_mature").withStyle(ChatFormatting.GREEN)
             ));
         }
+    }
+
+    @Override
+    public ResourceLocation getUid() {
+        return DTPHC2Blocks.PASSION_FRUIT_VINE.getId();
     }
 }

--- a/src/main/java/maxhyper/dtphc2/event/SpilePlacementEvent.java
+++ b/src/main/java/maxhyper/dtphc2/event/SpilePlacementEvent.java
@@ -32,13 +32,13 @@ public class SpilePlacementEvent {
     @SubscribeEvent
     public static void onPlayerRightClickBlock(PlayerInteractEvent.RightClickBlock event) {
 
-        Player player = event.getPlayer();
+        Player player = event.getEntity();
         InteractionHand hand = event.getHand();
         ItemStack heldItem = player.getItemInHand(hand);
 
         if (heldItem.getItem() != Items.IRON_INGOT) return;
 
-        Level world = event.getWorld();
+        Level world = event.getLevel();
         BlockPos pos = event.getPos();
         BlockState state = world.getBlockState(pos);
 

--- a/src/main/java/maxhyper/dtphc2/fruits/PalmPod.java
+++ b/src/main/java/maxhyper/dtphc2/fruits/PalmPod.java
@@ -12,8 +12,6 @@ import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.HorizontalDirectionalBlock;
 import net.minecraft.world.level.block.state.BlockState;
 
-import java.util.Random;
-
 public class PalmPod extends Pod {
 
     public static final TypedRegistry.EntryType<Pod> TYPE = TypedRegistry.newType(PalmPod::new);

--- a/src/main/java/maxhyper/dtphc2/genfeatures/VinesInTrunkGenFeature.java
+++ b/src/main/java/maxhyper/dtphc2/genfeatures/VinesInTrunkGenFeature.java
@@ -9,14 +9,13 @@ import maxhyper.dtphc2.blocks.FruitVineBlock;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.util.RandomSource;
 import net.minecraft.world.level.LevelAccessor;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.VineBlock;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.properties.BooleanProperty;
-
-import java.util.Random;
 
 public class VinesInTrunkGenFeature extends GenFeature {
 
@@ -58,7 +57,7 @@ public class VinesInTrunkGenFeature extends GenFeature {
 
     private void placeVines (GenFeatureConfiguration configuration, LevelAccessor world, BlockPos pos, Direction direction){
         BlockState state = configuration.get(BLOCK).defaultBlockState().setValue(sideVineStates[direction.getOpposite().ordinal()], true);
-        Random rand = world.getRandom();
+        RandomSource rand = world.getRandom();
         for (int i=0; i < configuration.get(MAX_HEIGHT); i++){
             BlockPos current = pos.above(i);
             if (VineBlock.isAcceptableNeighbour(world, current.above(), Direction.UP) || TreeHelper.isBranch(world.getBlockState(current.above())))

--- a/src/main/java/maxhyper/dtphc2/init/DTPHC2Registries.java
+++ b/src/main/java/maxhyper/dtphc2/init/DTPHC2Registries.java
@@ -20,6 +20,7 @@ import maxhyper.dtphc2.trees.FruitLogSpecies;
 import maxhyper.dtphc2.trees.GenOnExtraSoilSpecies;
 import maxhyper.dtphc2.trees.PaperbarkFamily;
 import net.minecraft.core.Registry;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.sounds.SoundEvent;
 import net.minecraft.tags.TagKey;
 import net.minecraft.world.level.block.Block;
@@ -94,7 +95,7 @@ public class DTPHC2Registries {
     }
 
     public static final FeatureCanceller TREE_CANCELLER = new DTPHC2TreeFeatureCanceller(DynamicTreesPHC2.location("tree"),
-            ColdFruitTreeFeature.class, ColdLogFruitTreeFeature.class, TemperateFruitTreeFeature.class, WarmFruitTreeFeature.class, WarmLogFruitTreeFeature.class);
+            ConfiguredFeatures.CONFIGURED_FEATURES.getEntries().stream().map(RegistryObject::getId).toArray(ResourceLocation[]::new));
 
     @SubscribeEvent
     public static void onFeatureCancellerRegistry(final RegistryEvent<FeatureCanceller> event) {

--- a/src/main/java/maxhyper/dtphc2/items/FruitVineItem.java
+++ b/src/main/java/maxhyper/dtphc2/items/FruitVineItem.java
@@ -6,8 +6,6 @@ import maxhyper.dtphc2.blocks.FruitVineBlock;
 import net.minecraft.ChatFormatting;
 import net.minecraft.core.BlockPos;
 import net.minecraft.network.chat.Component;
-import net.minecraft.network.chat.TextComponent;
-import net.minecraft.network.chat.TranslatableComponent;
 import net.minecraft.world.item.BlockItem;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.TooltipFlag;
@@ -15,7 +13,6 @@ import net.minecraft.world.level.Level;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import java.text.Format;
 import java.util.List;
 
 public class FruitVineItem extends BlockItem {
@@ -35,22 +32,22 @@ public class FruitVineItem extends BlockItem {
         int flags = getSeasonalTooltipFlags(world);
 
         if (flags != 0) {
-            tooltip.add(new TranslatableComponent("desc.sereneseasons.fertile_seasons").append(":"));
+            tooltip.add(Component.literal("desc.sereneseasons.fertile_seasons").append(":"));
 
             if ((flags & 15) == 15) {
-                tooltip.add(new TextComponent(" ").append(new TranslatableComponent("desc.sereneseasons.year_round").withStyle(ChatFormatting.LIGHT_PURPLE)));
+                tooltip.add(Component.literal(" ").append(Component.translatable("desc.sereneseasons.year_round").withStyle(ChatFormatting.LIGHT_PURPLE)));
             } else {
                 if ((flags & 1) != 0) {
-                    tooltip.add(new TextComponent(" ").append(new TranslatableComponent("desc.sereneseasons.spring").withStyle(ChatFormatting.GREEN)));
+                    tooltip.add(Component.literal(" ").append(Component.translatable("desc.sereneseasons.spring").withStyle(ChatFormatting.GREEN)));
                 }
                 if ((flags & 2) != 0) {
-                    tooltip.add(new TextComponent(" ").append(new TranslatableComponent("desc.sereneseasons.summer").withStyle(ChatFormatting.YELLOW)));
+                    tooltip.add(Component.literal(" ").append(Component.translatable("desc.sereneseasons.summer").withStyle(ChatFormatting.YELLOW)));
                 }
                 if ((flags & 4) != 0) {
-                    tooltip.add(new TextComponent(" ").append(new TranslatableComponent("desc.sereneseasons.autumn").withStyle(ChatFormatting.GOLD)));
+                    tooltip.add(Component.literal(" ").append(Component.translatable("desc.sereneseasons.autumn").withStyle(ChatFormatting.GOLD)));
                 }
                 if ((flags & 8) != 0) {
-                    tooltip.add(new TextComponent(" ").append(new TranslatableComponent("desc.sereneseasons.winter").withStyle(ChatFormatting.AQUA)));
+                    tooltip.add(Component.literal(" ").append(Component.translatable("desc.sereneseasons.winter").withStyle(ChatFormatting.AQUA)));
                 }
             }
         }

--- a/src/main/java/maxhyper/dtphc2/items/RipePeppercornItem.java
+++ b/src/main/java/maxhyper/dtphc2/items/RipePeppercornItem.java
@@ -1,7 +1,6 @@
 package maxhyper.dtphc2.items;
 
 import net.minecraft.network.chat.Component;
-import net.minecraft.network.chat.TranslatableComponent;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.TooltipFlag;
@@ -21,7 +20,7 @@ public class RipePeppercornItem extends Item {
 
     @Override @OnlyIn(Dist.CLIENT)
     public void appendHoverText(@Nonnull ItemStack pStack, @Nullable Level pLevel, List<Component> pTooltip, @Nonnull TooltipFlag pFlag) {
-        pTooltip.add(new TranslatableComponent("tooltip.dtphc2.ripe_peppercorn_item"));
+        pTooltip.add(Component.translatable("tooltip.dtphc2.ripe_peppercorn_item"));
     }
 
 }

--- a/src/main/java/maxhyper/dtphc2/models/ModelBakeEventHandler.java
+++ b/src/main/java/maxhyper/dtphc2/models/ModelBakeEventHandler.java
@@ -4,11 +4,9 @@ import maxhyper.dtphc2.DynamicTreesPHC2;
 import maxhyper.dtphc2.models.baked_models.MediumPalmLeavesBakedModel;
 import maxhyper.dtphc2.models.baked_models.LargePalmLeavesBakedModel;
 import maxhyper.dtphc2.models.baked_models.SmallPalmLeavesBakedModel;
-import net.minecraft.resources.ResourceLocation;
 import net.minecraftforge.api.distmarker.Dist;
-import net.minecraftforge.client.event.ModelBakeEvent;
-import net.minecraftforge.client.event.ModelRegistryEvent;
-import net.minecraftforge.client.model.ModelLoaderRegistry;
+import net.minecraftforge.client.event.ModelEvent.RegisterGeometryLoaders;
+import net.minecraftforge.client.event.ModelEvent.BakingCompleted;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
 
@@ -16,14 +14,14 @@ import net.minecraftforge.fml.common.Mod;
 public class ModelBakeEventHandler {
 
     @SubscribeEvent
-    public static void onModelRegistryEvent(ModelRegistryEvent event) {
-        ModelLoaderRegistry.registerLoader(new ResourceLocation(DynamicTreesPHC2.MOD_ID, "large_palm_fronds"), new PalmLeavesModelLoader(0));
-        ModelLoaderRegistry.registerLoader(new ResourceLocation(DynamicTreesPHC2.MOD_ID, "medium_palm_fronds"), new PalmLeavesModelLoader(1));
-        ModelLoaderRegistry.registerLoader(new ResourceLocation(DynamicTreesPHC2.MOD_ID, "small_palm_fronds"), new PalmLeavesModelLoader(2));
+    public static void onModelRegistryEvent(RegisterGeometryLoaders event) {
+        event.register("large_palm_fronds", new PalmLeavesModelLoader(0));
+        event.register("medium_palm_fronds", new PalmLeavesModelLoader(1));
+        event.register("small_palm_fronds", new PalmLeavesModelLoader(2));
     }
 
     @SubscribeEvent
-    public static void onModelBake(ModelBakeEvent event) {
+    public static void onModelBake(BakingCompleted event) {
         // Setup fronds models
         MediumPalmLeavesBakedModel.INSTANCES.forEach(MediumPalmLeavesBakedModel::setupModels);
         LargePalmLeavesBakedModel.INSTANCES.forEach(LargePalmLeavesBakedModel::setupModels);

--- a/src/main/java/maxhyper/dtphc2/models/PalmLeavesModelGeometry.java
+++ b/src/main/java/maxhyper/dtphc2/models/PalmLeavesModelGeometry.java
@@ -9,8 +9,8 @@ import net.minecraft.client.renderer.texture.TextureAtlas;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
 import net.minecraft.client.resources.model.*;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraftforge.client.model.IModelConfiguration;
-import net.minecraftforge.client.model.geometry.IModelGeometry;
+import net.minecraftforge.client.model.geometry.IGeometryBakingContext;
+import net.minecraftforge.client.model.geometry.IUnbakedGeometry;
 
 import javax.annotation.Nullable;
 import java.util.Collection;
@@ -19,11 +19,11 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.function.Function;
 
-public class PalmLeavesModelGeometry implements IModelGeometry<PalmLeavesModelGeometry> {
+public class PalmLeavesModelGeometry implements IUnbakedGeometry<PalmLeavesModelGeometry> {
 
     protected final ResourceLocation frondsResLoc;
 
-    private int frondType;
+    private final int frondType;
 
     public PalmLeavesModelGeometry (@Nullable final ResourceLocation frondsResLoc, int type){
         this.frondsResLoc = frondsResLoc;
@@ -31,20 +31,16 @@ public class PalmLeavesModelGeometry implements IModelGeometry<PalmLeavesModelGe
     }
 
     @Override
-    public BakedModel bake(IModelConfiguration owner, ModelBakery bakery, Function<Material, TextureAtlasSprite> spriteGetter, ModelState modelTransform, ItemOverrides overrides, ResourceLocation modelLocation) {
-        switch (frondType){
-            default:
-            case 0:
-                return new LargePalmLeavesBakedModel(modelLocation, frondsResLoc);
-            case 1:
-                return new MediumPalmLeavesBakedModel(modelLocation, frondsResLoc);
-            case 2:
-                return new SmallPalmLeavesBakedModel(modelLocation, frondsResLoc);
-        }
+    public BakedModel bake(IGeometryBakingContext owner, ModelBakery bakery, Function<Material, TextureAtlasSprite> spriteGetter, ModelState modelTransform, ItemOverrides overrides, ResourceLocation modelLocation) {
+        return switch (frondType) {
+            default -> new LargePalmLeavesBakedModel(modelLocation, frondsResLoc);
+            case 1 -> new MediumPalmLeavesBakedModel(modelLocation, frondsResLoc);
+            case 2 -> new SmallPalmLeavesBakedModel(modelLocation, frondsResLoc);
+        };
     }
 
     @Override
-    public Collection<Material> getTextures(IModelConfiguration owner, Function<ResourceLocation, UnbakedModel> modelGetter, Set<Pair<String, String>> missingTextureErrors) {
+    public Collection<Material> getMaterials(IGeometryBakingContext owner, Function<ResourceLocation, UnbakedModel> modelGetter, Set<Pair<String, String>> missingTextureErrors) {
         if (frondsResLoc == null) return new HashSet<>();
         return Collections.singleton(new Material(TextureAtlas.LOCATION_BLOCKS, frondsResLoc));
     }

--- a/src/main/java/maxhyper/dtphc2/models/PalmLeavesModelLoader.java
+++ b/src/main/java/maxhyper/dtphc2/models/PalmLeavesModelLoader.java
@@ -5,29 +5,25 @@ import com.google.gson.JsonObject;
 import net.minecraft.ResourceLocationException;
 import net.minecraft.client.renderer.texture.MissingTextureAtlasSprite;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraft.server.packs.resources.ResourceManager;
-import net.minecraftforge.client.model.IModelLoader;
+import net.minecraftforge.client.model.geometry.IGeometryLoader;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-public class PalmLeavesModelLoader implements IModelLoader<PalmLeavesModelGeometry> {
+public class PalmLeavesModelLoader implements IGeometryLoader<PalmLeavesModelGeometry> {
 
     public static final Logger LOGGER = LogManager.getLogger();
 
     private static final String FROND = "frond";
     private static final String TEXTURES = "textures";
 
-    private int frondType;
+    private final int frondType;
 
     public PalmLeavesModelLoader (int type){
         frondType = type;
     }
 
     @Override
-    public void onResourceManagerReload(ResourceManager resourceManager) { }
-
-    @Override
-    public PalmLeavesModelGeometry read(JsonDeserializationContext deserializationContext, JsonObject modelObject) {
+    public PalmLeavesModelGeometry read(JsonObject modelObject, JsonDeserializationContext deserializationContext) {
         final JsonObject textures = this.getTexturesObject(modelObject);
         return new PalmLeavesModelGeometry(getTextureLocation(textures, FROND), frondType);
     }

--- a/src/main/java/maxhyper/dtphc2/models/baked_models/LargePalmLeavesBakedModel.java
+++ b/src/main/java/maxhyper/dtphc2/models/baked_models/LargePalmLeavesBakedModel.java
@@ -4,15 +4,17 @@ import com.ferreusveritas.dynamictrees.block.leaves.PalmLeavesProperties;
 import com.ferreusveritas.dynamictrees.client.ModelUtils;
 import com.ferreusveritas.dynamictrees.util.CoordUtils;
 import com.google.common.primitives.Ints;
+import net.minecraft.client.renderer.RenderType;
 import net.minecraft.client.renderer.block.model.*;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
 import net.minecraft.client.resources.model.BakedModel;
 import net.minecraft.client.resources.model.SimpleBakedModel;
 import net.minecraft.core.Direction;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.util.RandomSource;
 import net.minecraft.world.level.block.state.BlockState;
-import net.minecraftforge.client.model.data.IDynamicBakedModel;
-import net.minecraftforge.client.model.data.IModelData;
+import net.minecraftforge.client.model.IDynamicBakedModel;
+import net.minecraftforge.client.model.data.ModelData;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -40,7 +42,7 @@ public class LargePalmLeavesBakedModel implements IDynamicBakedModel {
 
         for (CoordUtils.Surround surr : CoordUtils.Surround.values()) {
 
-            SimpleBakedModel.Builder builder = new SimpleBakedModel.Builder(blockModel.customData, ItemOverrides.EMPTY).particle(frondsTexture);
+            SimpleBakedModel.Builder builder = new SimpleBakedModel.Builder(blockModel, ItemOverrides.EMPTY, false).particle(frondsTexture);
 
             BlockVertexData[] quadData = {
                     new BlockVertexData(0, 0, 3, 15, 4),
@@ -182,7 +184,7 @@ public class LargePalmLeavesBakedModel implements IDynamicBakedModel {
 
     @Nonnull
     @Override
-    public List<BakedQuad> getQuads(@Nullable BlockState state, @Nullable Direction side, @Nonnull Random rand, @Nonnull IModelData extraData) {
+    public List<BakedQuad> getQuads(@Nullable BlockState state, @Nullable Direction side, @Nonnull RandomSource rand, @Nonnull ModelData extraData, @Nullable RenderType renderType) {
         if (state == null || side != null)
             return Collections.emptyList();
 
@@ -191,7 +193,7 @@ public class LargePalmLeavesBakedModel implements IDynamicBakedModel {
         int direction = state.getValue(PalmLeavesProperties.DynamicPalmLeavesBlock.DIRECTION);
 
         if (direction != 0)
-            quads.addAll(bakedFronds[direction-1].getQuads(state, null, rand, extraData));
+            quads.addAll(bakedFronds[direction-1].getQuads(state, null, rand, extraData, renderType));
 
 
         return quads;
@@ -238,11 +240,6 @@ public class LargePalmLeavesBakedModel implements IDynamicBakedModel {
     @Override
     public ItemOverrides getOverrides() {
         return ItemOverrides.EMPTY;
-    }
-
-    @Override
-    public boolean doesHandlePerspectives() {
-        return false;
     }
 
 //    public static class ModelPalmSurround implements IModelData {

--- a/src/main/java/maxhyper/dtphc2/models/baked_models/MediumPalmLeavesBakedModel.java
+++ b/src/main/java/maxhyper/dtphc2/models/baked_models/MediumPalmLeavesBakedModel.java
@@ -4,15 +4,17 @@ import com.ferreusveritas.dynamictrees.block.leaves.PalmLeavesProperties;
 import com.ferreusveritas.dynamictrees.client.ModelUtils;
 import com.ferreusveritas.dynamictrees.util.CoordUtils;
 import com.google.common.primitives.Ints;
+import net.minecraft.client.renderer.RenderType;
 import net.minecraft.client.renderer.block.model.*;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
 import net.minecraft.client.resources.model.BakedModel;
 import net.minecraft.client.resources.model.SimpleBakedModel;
 import net.minecraft.core.Direction;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.util.RandomSource;
 import net.minecraft.world.level.block.state.BlockState;
-import net.minecraftforge.client.model.data.IDynamicBakedModel;
-import net.minecraftforge.client.model.data.IModelData;
+import net.minecraftforge.client.model.IDynamicBakedModel;
+import net.minecraftforge.client.model.data.ModelData;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -40,7 +42,7 @@ public class MediumPalmLeavesBakedModel implements IDynamicBakedModel {
 
         for (CoordUtils.Surround surr : CoordUtils.Surround.values()) {
 
-            SimpleBakedModel.Builder builder = new SimpleBakedModel.Builder(blockModel.customData, ItemOverrides.EMPTY).particle(frondsTexture);
+            SimpleBakedModel.Builder builder = new SimpleBakedModel.Builder(blockModel, ItemOverrides.EMPTY, false).particle(frondsTexture);
 
             BlockVertexData[] quadData = {
                     new BlockVertexData(0, 0, 3, 15, 4),
@@ -149,7 +151,7 @@ public class MediumPalmLeavesBakedModel implements IDynamicBakedModel {
 
     @Nonnull
     @Override
-    public List<BakedQuad> getQuads(@Nullable BlockState state, @Nullable Direction side, @Nonnull Random rand, @Nonnull IModelData extraData) {
+    public List<BakedQuad> getQuads(@Nullable BlockState state, @Nullable Direction side, @Nonnull RandomSource rand, @Nonnull ModelData extraData, @Nullable RenderType renderType) {
         if (state == null || side != null)
             return Collections.emptyList();
 
@@ -158,7 +160,7 @@ public class MediumPalmLeavesBakedModel implements IDynamicBakedModel {
         int direction = state.getValue(PalmLeavesProperties.DynamicPalmLeavesBlock.DIRECTION);
 
         if (direction != 0)
-            quads.addAll(bakedFronds[direction-1].getQuads(state, null, rand, extraData));
+            quads.addAll(bakedFronds[direction-1].getQuads(state, null, rand, extraData, renderType));
 
 
         return quads;
@@ -205,11 +207,6 @@ public class MediumPalmLeavesBakedModel implements IDynamicBakedModel {
     @Override
     public ItemOverrides getOverrides() {
         return ItemOverrides.EMPTY;
-    }
-
-    @Override
-    public boolean doesHandlePerspectives() {
-        return false;
     }
 
     public static class BlockVertexData {

--- a/src/main/java/maxhyper/dtphc2/models/baked_models/SmallPalmLeavesBakedModel.java
+++ b/src/main/java/maxhyper/dtphc2/models/baked_models/SmallPalmLeavesBakedModel.java
@@ -4,15 +4,17 @@ import com.ferreusveritas.dynamictrees.block.leaves.PalmLeavesProperties;
 import com.ferreusveritas.dynamictrees.client.ModelUtils;
 import com.ferreusveritas.dynamictrees.util.CoordUtils;
 import com.google.common.primitives.Ints;
+import net.minecraft.client.renderer.RenderType;
 import net.minecraft.client.renderer.block.model.*;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
 import net.minecraft.client.resources.model.BakedModel;
 import net.minecraft.client.resources.model.SimpleBakedModel;
 import net.minecraft.core.Direction;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.util.RandomSource;
 import net.minecraft.world.level.block.state.BlockState;
-import net.minecraftforge.client.model.data.IDynamicBakedModel;
-import net.minecraftforge.client.model.data.IModelData;
+import net.minecraftforge.client.model.IDynamicBakedModel;
+import net.minecraftforge.client.model.data.ModelData;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -40,7 +42,7 @@ public class SmallPalmLeavesBakedModel implements IDynamicBakedModel {
 
         for (CoordUtils.Surround surr : CoordUtils.Surround.values()) {
 
-            SimpleBakedModel.Builder builder = new SimpleBakedModel.Builder(blockModel.customData, ItemOverrides.EMPTY).particle(frondsTexture);
+            SimpleBakedModel.Builder builder = new SimpleBakedModel.Builder(blockModel, ItemOverrides.EMPTY, false).particle(frondsTexture);
 
             BlockVertexData[] quadData = {
                     new BlockVertexData(0, 0, 2, 10, 4),
@@ -141,7 +143,7 @@ public class SmallPalmLeavesBakedModel implements IDynamicBakedModel {
 
     @Nonnull
     @Override
-    public List<BakedQuad> getQuads(@Nullable BlockState state, @Nullable Direction side, @Nonnull Random rand, @Nonnull IModelData extraData) {
+    public List<BakedQuad> getQuads(@Nullable BlockState state, @Nullable Direction side, @Nonnull RandomSource rand, @Nonnull ModelData extraData, @Nullable RenderType renderType) {
         if (state == null || side != null)
             return Collections.emptyList();
 
@@ -150,7 +152,7 @@ public class SmallPalmLeavesBakedModel implements IDynamicBakedModel {
         int direction = state.getValue(PalmLeavesProperties.DynamicPalmLeavesBlock.DIRECTION);
 
         if (direction != 0)
-            quads.addAll(bakedFronds[direction-1].getQuads(state, null, rand, extraData));
+            quads.addAll(bakedFronds[direction-1].getQuads(state, null, rand, extraData, renderType));
 
 
         return quads;
@@ -197,11 +199,6 @@ public class SmallPalmLeavesBakedModel implements IDynamicBakedModel {
     @Override
     public ItemOverrides getOverrides() {
         return ItemOverrides.EMPTY;
-    }
-
-    @Override
-    public boolean doesHandlePerspectives() {
-        return false;
     }
 
 //    public static class ModelPalmSurround implements IModelData {

--- a/src/main/java/maxhyper/dtphc2/trees/PaperbarkFamily.java
+++ b/src/main/java/maxhyper/dtphc2/trees/PaperbarkFamily.java
@@ -9,6 +9,7 @@ import com.ferreusveritas.dynamictrees.tree.family.Family;
 import net.minecraft.core.BlockPos;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerLevel;
+import net.minecraft.util.RandomSource;
 import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
@@ -16,8 +17,6 @@ import net.minecraft.world.item.Items;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.Vec3;
-
-import java.util.Random;
 
 public class PaperbarkFamily extends Family {
 
@@ -51,7 +50,7 @@ public class PaperbarkFamily extends Family {
 
             @SuppressWarnings("deprecation")
             @Override
-            public void tick(BlockState state, ServerLevel world, BlockPos pos, Random rand) {
+            public void tick(BlockState state, ServerLevel world, BlockPos pos, RandomSource rand) {
                 if (rand.nextFloat() < barkRegrowChance && isStrippedBranch()){
                     int radius = TreeHelper.getRadius(world, pos);
                     int radiusDown = TreeHelper.isBranch(world.getBlockState(pos.below())) ? TreeHelper.getRadius(world, pos.below()) : getMaxRadius();

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -1,5 +1,5 @@
 modLoader="javafml"
-loaderVersion="[40,)"
+loaderVersion="[43,44)"
 license="MIT"
 
 [[mods]]
@@ -18,28 +18,28 @@ Compatibility Mod between Dynamic Trees and Pam's HarvestCraft 2: Trees
 [[dependencies.dtphc2]]
     modId="forge"
     mandatory=true
-    versionRange="[40,)"
+    versionRange="[43.2.0,44)"
     ordering="NONE"
     side="BOTH"
 
 [[dependencies.dtphc2]]
     modId="minecraft"
     mandatory=true
-    versionRange="[1.18.2,1.19)"
+    versionRange="[1.19.2,1.19.3)"
     ordering="NONE"
     side="BOTH"
 
 [[dependencies.dtphc2]]
     modId="dynamictrees"
     mandatory=true
-    versionRange="[0.11.0,)"
+    versionRange="[1.1.0-BETA5,)"
     ordering="AFTER"
     side="BOTH"
 
 [[dependencies.dtphc2]]
     modId="dynamictreesplus"
     mandatory=false
-    versionRange="[0.1.0,)"
+    versionRange="[1.1.1,)"
     ordering="AFTER"
     side="BOTH"
 

--- a/src/main/resources/assets/dtphc2/lang/en_us.json
+++ b/src/main/resources/assets/dtphc2/lang/en_us.json
@@ -139,6 +139,8 @@
 
   "tooltip.waila.crop_growth" : "Maturity: %s",
   "tooltip.waila.crop_mature": "Ripe",
+  "config.jade.plugin_dtphc2.maple_spile": "Spile",
+  "config.jade.plugin_dtphc2.passion_fruit_vine": "Passion Fruit Vines",
 
   "item.pamhc2trees.coconutitem": "Coconut Slice",
   "item.pamhc2trees.maplesyrupitem": "Maple Syrup",

--- a/src/main/resources/assets/dtphc2/lang/en_us.json
+++ b/src/main/resources/assets/dtphc2/lang/en_us.json
@@ -137,6 +137,9 @@
   "tooltip.dtphc2.maple_spile_not_filled": "Empty",
   "tooltip.dtphc2.maple_spile_bucket_filling": "Filled: %s",
 
+  "tooltip.waila.crop_growth" : "Maturity: %s",
+  "tooltip.waila.crop_mature": "Ripe",
+
   "item.pamhc2trees.coconutitem": "Coconut Slice",
   "item.pamhc2trees.maplesyrupitem": "Maple Syrup",
   "item.pamhc2trees.eucalyptusitem": "Eucalyptus Leaves",


### PR DESCRIPTION
### Context

It is not intended to be merged like that because a new branch should be created AND there are still issues.

First, the goal was to go as direct as possible to the migration.

### What is working per my test?

- The build, MC can be launched without crashes and the world is being generated

### What is NOT working?

- Some items/trees are missing in PamsHC2 - Trees (at least pamrubber and eucalyptusitem)
  - Quite a lot of things have changed in the PMHC2-Tree mod but I can't access the code directly in the repo for the release 1.19.2 https://github.com/MatrexsVigil/phc2trees/tree/1.18.2
```
[17:35:07] [Worker-Main-3/ERROR] [co.fe.dy.ap.re.lo.pr.JsonRegistryResourceLoader/]: Error whilst loading type "Family" with name "dtphc2:rubber": [primitive_log] Could not find block for registry name 'pamhc2trees:pamrubber'.
[17:35:07] [Worker-Main-3/ERROR] [co.fe.dy.ap.re.lo.pr.JsonRegistryResourceLoader/]: Error whilst loading type "Family" with name "dtphc2:rubber": [primitive_stripped_log] Could not find block for registry name 'pamhc2trees:pamrubber'.
```
or
```
[17:36:14] [Render thread/ERROR] [minecraft/LootTables]: Couldn't parse loot table dtphc2:trees/branches/stripped_rubber
com.google.gson.JsonSyntaxException: Expected name to be an item, was unknown string 'pamhc2trees:pamrubber'
[17:36:15] [Render thread/ERROR] [minecraft/LootTables]: Couldn't parse loot table dtphc2:trees/leaves/eucalyptus
com.google.gson.JsonSyntaxException: Expected name to be an item, was unknown string 'pamhc2trees:eucalyptusitem'
[17:36:17] [Render thread/ERROR] [minecraft/LootTables]: Couldn't parse loot table dtphc2:blocks/eucalyptus_leaves
com.google.gson.JsonSyntaxException: Expected name to be an item, was unknown string 'pamhc2trees:eucalyptusitem'
```
or
```
[17:53:56] [Worker-Main-3/WARN] [minecraft/ModelBakery]: Exception loading blockstate definition: 'dtphc2:blockstates/eucalyptus_fruit.json' missing model for variant: 'dtphc2:eucalyptus_fruit#age=0'
[17:53:56] [Worker-Main-3/WARN] [minecraft/ModelBakery]: Exception loading blockstate definition: 'dtphc2:blockstates/eucalyptus_fruit.json' missing model for variant: 'dtphc2:eucalyptus_fruit#age=1'
[17:53:56] [Worker-Main-3/WARN] [minecraft/ModelBakery]: Exception loading blockstate definition: 'dtphc2:blockstates/eucalyptus_fruit.json' missing model for variant: 'dtphc2:eucalyptus_fruit#age=2'
[17:53:56] [Worker-Main-3/WARN] [minecraft/ModelBakery]: Exception loading blockstate definition: 'dtphc2:blockstates/eucalyptus_fruit.json' missing model for variant: 'dtphc2:eucalyptus_fruit#age=3'
```
- There is a weird rendering on the map with circles of concrete
- Only a few PODs are being registered in the creative (both for Dynamic Trees and this mod).
  - Cocoa Pods and Jungle pods for DT, only the rubber Tree Pod for this mode
  
### Code issues
  
The main element that I didn't find a good solution is for the feature canceller, I can get the same Feature from the PMHC2-Tree mod. So I decided to loop over all of them and use the `ResourceLocation`. 
I'm not sure it works as intended.
Related commit: https://github.com/DynamicTreesTeam/DynamicTrees-PHC2/commit/1481c5c34f390801835c7617c3b8d506db20fdd6